### PR TITLE
Modules related to Zabbix items and problems

### DIFF
--- a/plugins/modules/zabbix_item_info.py
+++ b/plugins/modules/zabbix_item_info.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) gaudenz.steinlin@cloudscale.ch
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+RETURN = r'''
+---
+hosts:
+  description: List of Zabbix items. See https://www.zabbix.com/documentation/current/en/manual/api/reference/item/object for list of item values.
+  returned: success
+  type: list
+  elements: dict
+  sample: [{"itemid": "25550", "type": "18", "snmp_oid": "", "hostid": "10116", "name": "Days", ... }]
+'''
+
+DOCUMENTATION = r'''
+---
+module: zabbix_item_info
+short_description: Gather information about Zabbix items
+description:
+   - This module allows you to search for Zabbix item entries.
+author:
+    - "Gaudenz Steinlin (@gaudenz)"
+requirements:
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
+options:
+    host:
+        description:
+            - Return only items that belong to a host with the given name.
+        required: false
+        type: str
+    monitored:
+        description:
+            - If set to true return only enabled items that belong to monitored
+              hosts.
+        required: false
+        default: None
+        type: bool
+    with_triggers:
+        description:
+            - If set to true return only items that are used in triggers.
+        required: false
+        default: None
+        type: bool
+    item_inventory:
+        description:
+            - List of item inventory keys to display in the result.
+            - All keys are retrieved if no key is specified.
+        type: list
+        elements: str
+        required: false
+extends_documentation_fragment:
+- community.zabbix.zabbix
+
+'''
+
+EXAMPLES = r'''
+- name: Get host info
+  local_action:
+    module: community.zabbix.zabbix_item_info
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    name: ExampleHost
+    timeout: 10
+
+- name: Reduce host inventory information to provided keys
+  local_action:
+    module: community.zabbix.zabbix_item_info
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    name: ExampleHost
+    item_inventory:
+      - itemid
+      - type
+    timeout: 10
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+
+class Item(ZabbixBase):
+    def get_items(self, host, monitored, with_triggers, item_inventory):
+        """ Get items """
+        return self._zapi.item.get({
+            'host': host,
+            'monitored': monitored,
+            'with_triggers': with_triggers,
+            'output': item_inventory,
+        })
+
+
+def main():
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        host=dict(type='str', default='', required=False),
+        monitored=dict(type='bool', required=False, default=None),
+        with_triggers=dict(type='bool', required=False, default=None),
+        item_inventory=dict(type='list', default=[], required=False)
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    monitored = module.params['monitored']
+    with_triggers = module.params['with_triggers']
+    item_inventory = module.params['item_inventory']
+
+    if not item_inventory:
+        item_inventory = 'extend'
+
+    item = Item(module)
+
+    items = item.get_items(host, monitored, with_triggers, item_inventory)
+    module.exit_json(ok=True, items=items)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zabbix_problem_action.py
+++ b/plugins/modules/zabbix_problem_action.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) gaudenz.steinlin@cloudscale.ch
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+RETURN = r'''
+---
+hosts:
+  description: Acknowledge or close Zabbix problems. See
+  https://www.zabbix.com/documentation/current/en/manual/api/reference/event.
+  returned: success
+  type: list
+  elements: dict
+  sample: []
+'''
+
+DOCUMENTATION = r'''
+---
+module: zabbix_problem_action
+short_description: Modify Zabbix problems
+description:
+   - Acknowledge or close Zabbix problems.
+   - Add a message to Zabbix problems.
+   - Change a problems severity.
+author:
+    - "Gaudenz Steinlin (@gaudenz)"
+requirements:
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
+options:
+    eventid:
+        description:
+            - ID of the problem event.
+        required: true
+        type: int
+    action:
+        description:
+             - Action to perform
+        required: true
+        choices: [close, acknowledge, message, severity, unacknowledge]
+        type: str
+    message:
+        description:
+            - Message to add to the problem.
+            - Required if action is "message".
+        required: false
+        type: str
+    severity:
+        descripton:
+            - New severity of the problem.
+            - Required if action is "severity"
+        required: false
+        choices: [0, 1, 2, 3, 4, 5]
+        type: int
+extends_documentation_fragment:
+- community.zabbix.zabbix
+
+'''
+
+EXAMPLES = r'''
+- name: Get host info
+  local_action:
+    module: community.zabbix.zabbix_problem_info
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    name: ExampleHost
+    timeout: 10
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+ACTION_MAP = {
+    'close': 1,
+    'acknowledge': 2,
+    'message': 4,
+    'severity': 8,
+    'unacknowledge': 16,
+}
+
+class ProblemAction(ZabbixBase):
+    def acknowledge(self, eventid, action, message=None, severity=None):
+        """" Acknowledge" problems
+
+        This method is used to do any modification on problems. Not just acknowledge them.
+        """
+
+        parameters = {
+            'eventids': eventid,
+            'action': ACTION_MAP[action],
+        }
+
+        if action == 'message':
+            parameters['message'] = message
+        elif action == 'severity':
+            parameters['severity'] = severity
+
+        return self._zapi.event.acknowledge(parameters)
+
+
+def main():
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        eventid=dict(type='int', required=True),
+        action=dict(type='str', choices=['close', 'acknowledge', 'message', 'severity', 'unacknowledge'], required=True),
+        message=dict(type='str', required=False),
+        severity=dict(type='int', choices=[0,1,2,3,4,5], required=False),
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False,
+        required_if=[
+            ['action', 'message', ['message']],
+            ['action', 'severity', ['severity']],
+        ],
+    )
+
+    problem = ProblemAction(module)
+
+    module.exit_json(ok=True,
+                     changed=True,
+                     problems=problem.acknowledge(
+                         module.params['eventid'],
+                         module.params['action'],
+                         module.params['message'],
+                         module.params['severity'],
+                     ))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zabbix_problem_info.py
+++ b/plugins/modules/zabbix_problem_info.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) gaudenz.steinlin@cloudscale.ch
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+RETURN = r'''
+---
+problems:
+  description: List of Zabbix problems. See
+  https://www.zabbix.com/documentation/current/en/manual/api/reference/problem.
+  returned: success
+  type: list
+  elements: dict
+  sample: []
+'''
+
+DOCUMENTATION = r'''
+---
+module: zabbix_problem_info
+short_description: Gather information about Zabbix problems
+description:
+   - This module allows you to search for Zabbix problems.
+author:
+    - "Gaudenz Steinlin (@gaudenz)"
+requirements:
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
+options:
+    host:
+        description:
+            - Return problems for the host with this name.
+        required: true
+        type: str
+   severities:
+        description:
+            - Return only problems with the given severities
+        required: false
+        type: list
+        elements: int
+        default: [1,2,3,4,5]
+   acknowledged:
+        description:
+            - If true return only acknowledged problems
+        required: false
+        type: bool
+        default: None
+   suppressed:
+        description:
+            - If true return only problems in maintenance.
+        required: false
+        type: bool
+        default: None
+extends_documentation_fragment:
+- community.zabbix.zabbix
+
+'''
+
+EXAMPLES = r'''
+- name: Get host info
+  local_action:
+    module: community.zabbix.zabbix_problem_info
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    name: ExampleHost
+    timeout: 10
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+
+class Problem(ZabbixBase):
+    def get_problems(self, host, severities, acknowledged, suppressed):
+        """ Get problems"""
+        hostids = self._zapi.host.get({
+            'filter': {
+                'host': [host, ],
+            },
+            'output': ['hostid'],
+        })
+        return self._zapi.problem.get({
+            'hostids': [h['hostid'] for h in hostids],
+            'severities': severities,
+            'acknowledged': acknowledged,
+            'suppressed': suppressed,
+        })
+
+
+def main():
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        host=dict(type='str', required=True),
+        severities=dict(type='list', elements='int', default=[1,2,3,4,5], required=False),
+        acknowledged=dict(type='bool', default=None, required=False),
+        suppressed=dict(type='bool', default=None, required=False),
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    severities = module.params['severities']
+    acknowledged = module.params['acknowledged']
+    suppressed = module.params['suppressed']
+
+    problem = Problem(module)
+
+    module.exit_json(ok=True, problems=problem.get_problems(host,
+                                                            severities,
+                                                            acknowledged,
+                                                            suppressed,
+                                                            ))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zabbix_task.py
+++ b/plugins/modules/zabbix_task.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2013-2014, Epic Games, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: zabbix_task
+short_description: Create Zabbix tasks
+description:
+   - Create Zabbix tasks: https://www.zabbix.com/documentation/current/en/manual/api/reference/task
+   - This can be used to force data collection on an item.
+author:
+    - Gaudenz Steinlin (@gaudenz)
+requirements:
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
+options:
+    items:
+        description:
+            - Items to force data collection
+        required: true
+        type: list
+        elements: int
+
+extends_documentation_fragment:
+- community.zabbix.zabbix
+'''
+
+EXAMPLES = r'''
+- name: Force data collection
+  local_action:
+    module: community.zabbix.zabbix_task
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    items:
+      - 1234
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+
+class Task(ZabbixBase):
+    def create_task(self, items):
+        return self._zapi.task.create([
+            {'type': 6, # check now
+             'request': {
+                 'itemid': i,
+                 },
+             } for i in items
+        ])
+
+
+def main():
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        items=dict(type='list', required=True),
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    items = module.params['items']
+
+    task = Task(module)
+
+    # create task
+    tasks = task.create_task(items)
+    if len(tasks) > 0:
+        module.exit_json(
+            changed=True,
+            result="Successfully created task(s): %s" % tasks,
+        )
+    else:
+        module.exit_json(changed=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
These modules allow you to get all the items and problems for a host and to close problems. This is useful to do cleanup after a maintenance and to check if there are any open problems before ending a maintenance.

This is an updated pull request from #1 to only add these modules without updating the rest of the Ansible collection. It also fixes one problem mentioned in the review for #1.